### PR TITLE
Support for setting default values

### DIFF
--- a/SSRadioButtonController/SSRadioButtonsController.swift
+++ b/SSRadioButtonController/SSRadioButtonsController.swift
@@ -22,7 +22,7 @@ import UIKit
 class SSRadioButtonsController : NSObject
 {
     fileprivate var buttonsArray = [UIButton]()
-    fileprivate weak var currentSelectedButton:UIButton? = nil
+//    fileprivate weak var currentSelectedButton:UIButton? = nil
     weak var delegate : SSRadioButtonControllerDelegate? = nil
     /**
         Set whether a selected radio button can be deselected or not. Default value is false.
@@ -64,9 +64,6 @@ class SSRadioButtonsController : NSObject
             buttonsArray.remove(at: buttonsArray.index(of: iteratingButton!)!)
             iteratingButton!.removeTarget(self, action: #selector(SSRadioButtonsController.pressed(_:)), for: UIControlEvents.touchUpInside)
             iteratingButton!.isSelected = false
-            if currentSelectedButton == iteratingButton {
-                currentSelectedButton = nil
-            }
         }
     }
     /**
@@ -82,6 +79,7 @@ class SSRadioButtonsController : NSObject
     }
 
     func pressed(_ sender: UIButton) {
+        var currentSelectedButton: UIButton? = nil
         if(sender.isSelected) {
             if shouldLetDeSelect {
                 sender.isSelected = false
@@ -102,6 +100,8 @@ class SSRadioButtonsController : NSObject
         - returns: Currenlty selected button.
     */
     func selectedButton() -> UIButton? {
-        return currentSelectedButton
+        guard let index = buttonsArray.index(where: { button in button.isSelected }) else { return nil }
+        
+        return buttonsArray[index]
     }
 }


### PR DESCRIPTION
Hi. I've slightly modified the SSRadioButtonController to simplify setting a default value for buttons in a button group.

The problem in previous implementation is that it tracked the current selection by observing the taps on the button and maintaining a selection variable. This makes it difficult to add a default selection button by simply setting the "isSelected" property of the button during setup (the controller will not have knowledge of the selection unless the tapping event is also programmatically triggered).

My solution is to get rid of the variable that tracked the current selection and to simply iterate through the buttons array when selectedButton() is called. I would argue that despite being less efficient it simplifies the code and solves the above problem. Also, on current devices the iteration takes very little time (I would guess well under 1 millisecond) unless the number of buttons is unusually large. If my previous guess was correct, then to be noticeable the size of the array would need to grow at least into the thousands: arguably not the typical usage of this kind of control.

I really hope that you find the changes worth to be integrated into the main project.

By the way, thanks for sharing your code. You saved me a bunch of coding today :-)




