### PR TITLE
Added support for selecting multiple radio buttons at a time. Useful …

### DIFF
--- a/SSRadioButtonController/SSRadioButtonsController.swift
+++ b/SSRadioButtonController/SSRadioButtonsController.swift
@@ -12,47 +12,50 @@ import UIKit
 /// RadioButtonControllerDelegate. Delegate optionally implements didSelectButton that receives selected button.
 @objc protocol SSRadioButtonControllerDelegate {
     /**
-        This function is called when a button is selected. If 'shouldLetDeSelect' is true, and a button is deselected, this function
-    is called with a nil.
-    
-    */
+     This function is called when a button is selected. If 'shouldLetDeSelect' is true, and a button is deselected, this function
+     is called with a nil.
+     
+     */
     @objc func didSelectButton(selectedButton: UIButton?)
 }
 
 class SSRadioButtonsController : NSObject
 {
     fileprivate var buttonsArray = [UIButton]()
+    fileprivate var currentSelectedButtons:[UIButton] = [UIButton]()
+    fileprivate var selectableButtons = 0
     weak var delegate : SSRadioButtonControllerDelegate? = nil
     /**
-        Set whether a selected radio button can be deselected or not. Default value is false.
-    */
+     Set whether a selected radio button can be deselected or not. Default value is false.
+     */
     var shouldLetDeSelect = false
     /**
-        Variadic parameter init that accepts UIButtons.
-
-        - parameter buttons: Buttons that should behave as Radio Buttons
-    */
-    init(buttons: UIButton...) {
+     Variadic parameter init that accepts UIButtons.
+     
+     - parameter buttons: Buttons that should behave as Radio Buttons
+     */
+    init(buttons: UIButton..., selectableBtns: Int = 1) {
         super.init()
         for aButton in buttons {
             aButton.addTarget(self, action: #selector(SSRadioButtonsController.pressed(_:)), for: UIControlEvents.touchUpInside)
         }
         self.buttonsArray = buttons
+        selectableButtons = selectableBtns
     }
     /**
-        Add a UIButton to Controller
-
-        - parameter button: Add the button to controller.
-    */
+     Add a UIButton to Controller
+     
+     - parameter button: Add the button to controller.
+     */
     func addButton(_ aButton: UIButton) {
         buttonsArray.append(aButton)
         aButton.addTarget(self, action: #selector(SSRadioButtonsController.pressed(_:)), for: UIControlEvents.touchUpInside)
     }
-    /** 
-        Remove a UIButton from controller.
-
-        - parameter button: Button to be removed from controller.
-    */
+    /**
+     Remove a UIButton from controller.
+     
+     - parameter button: Button to be removed from controller.
+     */
     func removeButton(_ aButton: UIButton) {
         var iteratingButton: UIButton? = nil
         if(buttonsArray.contains(aButton))
@@ -66,41 +69,62 @@ class SSRadioButtonsController : NSObject
         }
     }
     /**
-        Set an array of UIButons to behave as controller.
-        
-        - parameter buttonArray: Array of buttons
-    */
+     Set an array of UIButons to behave as controller.
+     
+     - parameter buttonArray: Array of buttons
+     */
     func setButtonsArray(_ aButtonsArray: [UIButton]) {
         for aButton in aButtonsArray {
             aButton.addTarget(self, action: #selector(SSRadioButtonsController.pressed(_:)), for: UIControlEvents.touchUpInside)
         }
         buttonsArray = aButtonsArray
     }
-
+    
     func pressed(_ sender: UIButton) {
-        var currentSelectedButton: UIButton? = nil
         if(sender.isSelected) {
             if shouldLetDeSelect {
+                var index = 0
+                for button in currentSelectedButtons {
+                    if button == sender {
+                        currentSelectedButtons.remove(at: index)
+                    }
+                    index += 1
+                }
                 sender.isSelected = false
-                currentSelectedButton = nil
             }
         } else {
-            for aButton in buttonsArray {
-                aButton.isSelected = false
+            if (currentSelectedButtons.count <= selectableButtons) {
+                sender.isSelected = true
+                if (currentSelectedButtons.count == selectableButtons) {
+                    currentSelectedButtons[0].isSelected = false
+                    currentSelectedButtons.remove(at: 0)
+                }
+                currentSelectedButtons.append(sender)
             }
-            sender.isSelected = true
-            currentSelectedButton = sender
         }
-        delegate?.didSelectButton(selectedButton: currentSelectedButton)
+        delegate?.didSelectButton(selectedButton: sender)
     }
     /**
-        Get the currently selected button.
-    
-        - returns: Currenlty selected button.
-    */
+     Get the currently selected button.
+     
+     - returns: Currenlty selected button.
+     */
     func selectedButton() -> UIButton? {
-        guard let index = buttonsArray.index(where: { button in button.isSelected }) else { return nil }
-        
-        return buttonsArray[index]
+        if currentSelectedButtons.count == 1 {
+            guard let index = buttonsArray.index(where: { button in button.isSelected }) else { return nil }
+            
+            return buttonsArray[index]
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Get the currently selected buttons. Used when the user is able to select multiple buttons.
+     
+     - returns: Currenlty selected buttons.
+     */
+    func selectedButtons() -> [UIButton] {
+        return currentSelectedButtons
     }
 }


### PR DESCRIPTION
…for example if you're creating a multiple choice quiz app in which some questions allow more than one answer (my use case when I made these changes awhile ago). By default, the number of selectable buttons is still 1 and everything functions the exact same unless you change the parameter selectableBtns to something other than 1. It also deselects the least recently selected button if you try to select more than the specified amount. 

To test it out, go into the sample view controller and change
```Swift
radioButtonController = SSRadioButtonsController(buttons: button1, button2, button3)
//To:
radioButtonController = SSRadioButtonsController(buttons: button1, button2, button3, selectableBtns: 2)
```

Also, sorry about some of the random white space changes - those were an accident on my part. Let me know if it's an issue and I'll go through and undo them.